### PR TITLE
Update Gradle Wrapper from 8.10.2 to 8.11

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionSha256Sum=57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/test-data/src/commonMain/kotlin/org/hildan/accounting/testdata/JHHisgenpadMortgage.kt
+++ b/test-data/src/commonMain/kotlin/org/hildan/accounting/testdata/JHHisgenpadMortgage.kt
@@ -13,7 +13,7 @@ private val optionsPrice = 56_913.eur
 // Based on initial options price estimate, and now recorded as such by Obvion
 private val estimatedWozValue = landPrice + constructionPrice + parkingPrice + 38_633.eur
 
-private val startDate = LocalDate(year = 2024, monthNumber = 11, dayOfMonth = 17)
+private val startDate = LocalDate(year = 2023, monthNumber = 11, dayOfMonth = 17)
 
 // From: https://www.obvion.nl/Hypotheek-rente/Actuele-hypotheekrente-Obvion?duurzaamheidskorting=Ja
 // The following rates were locked in on 2023-09-11
@@ -27,16 +27,17 @@ private val ObvionRateSept2023 = InterestRate.DynamicLtv(
     )
 )
 
+// these dates are not the dates of the bills, but the dates of the payments themselves
 private val constructionBillsPayments = listOf(
-    Payment(date = LocalDate.parse("2024-01-16"), amount = constructionPrice * 3.pct),
-    Payment(date = LocalDate.parse("2024-04-18"), amount = constructionPrice * 10.pct),
-    Payment(date = LocalDate.parse("2024-06-11"), amount = constructionPrice * 15.pct),
-    Payment(date = LocalDate.parse("2024-06-16"), amount = constructionPrice * 10.pct),
-    Payment(date = LocalDate.parse("2024-08-01"), amount = constructionPrice * 5.pct),      // TODO add real date
-    Payment(date = LocalDate.parse("2024-09-01"), amount = constructionPrice * "23.5".pct), // TODO add real date
-    Payment(date = LocalDate.parse("2024-10-01"), amount = constructionPrice * 10.pct),     // TODO add real date
-    Payment(date = LocalDate.parse("2024-11-01"), amount = constructionPrice * "13.5".pct), // TODO add real date
-    Payment(date = LocalDate.parse("2025-07-01"), amount = constructionPrice * 10.pct), // on delivery date
+    Payment(date = LocalDate.parse("2024-01-16"), amount = constructionPrice * 3.pct),      // T1
+    Payment(date = LocalDate.parse("2024-04-18"), amount = constructionPrice * 10.pct),     // T2
+    Payment(date = LocalDate.parse("2024-06-11"), amount = constructionPrice * 15.pct),     // T3
+    Payment(date = LocalDate.parse("2024-06-16"), amount = constructionPrice * 10.pct),     // T4
+    Payment(date = LocalDate.parse("2024-12-01"), amount = constructionPrice * 5.pct),      // T5 TODO add real date
+    Payment(date = LocalDate.parse("2025-01-15"), amount = constructionPrice * "23.5".pct), // T6 TODO add real date
+    Payment(date = LocalDate.parse("2024-11-11"), amount = constructionPrice * 10.pct),     // T7
+    Payment(date = LocalDate.parse("2024-11-01"), amount = constructionPrice * "13.5".pct), // T8 TODO add real date
+    Payment(date = LocalDate.parse("2025-09-01"), amount = constructionPrice * 10.pct), // on delivery date TODO add real date
 )
 
 val jhHisgenpadSimulationIncremental = SimulationSettings(
@@ -46,6 +47,10 @@ val jhHisgenpadSimulationIncremental = SimulationSettings(
         annualInterestRate = ObvionRateSept2023,
         startDate = startDate,
         termInYears = 30,
+        extraPayments = listOf(
+            Payment(LocalDate.parse("2024-06-07"), 50_000.eur),
+            Payment(LocalDate.parse("2024-06-13"), "12202.92".eur),
+        )
     ),
     property = Property.NewConstruction(
         initialNotaryPayment = Payment(startDate, landPrice),


### PR DESCRIPTION
Update Gradle Wrapper from 8.10.2 to 8.11.

Read the release notes: https://docs.gradle.org/8.11/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `8.11`
- Distribution (-bin) zip checksum: `57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9`
- Wrapper JAR Checksum: `2db75c40782f5e8ba1fc278a5574bab070adccb2d21ca5a6e5ed840888448046`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>